### PR TITLE
Remove need for region and account uuid vars.

### DIFF
--- a/blueprints/drill/terraform/_interface.tf
+++ b/blueprints/drill/terraform/_interface.tf
@@ -16,10 +16,6 @@ variable "project_name" {
   description = "The name of this project. This value may be used for naming resources."
 }
 
-variable "triton_account_uuid" {
-  description = "The Triton account UUID."
-}
-
 variable "manta_url" {
   default     = "https://us-east.manta.joyent.com/"
   description = "The URL of the Manta service endpoint."
@@ -40,11 +36,6 @@ variable "manta_key" {
 #
 # Default Variables.
 #
-variable "triton_region" {
-  default     = "us-east-1"
-  description = "The region to provision resources within."
-}
-
 variable "network_name_private" {
   default     = "My-Fabric-Network"
   description = "The network name for private network access.."
@@ -53,11 +44,6 @@ variable "network_name_private" {
 variable "count_drill_workers" {
   default     = "3"
   description = "The number of Drill workers to provision."
-}
-
-variable "key_path_public" {
-  default     = "~/.ssh/id_rsa.pub"
-  description = "Path to the public key to use for connecting to machines."
 }
 
 variable "key_path_private" {
@@ -131,7 +117,6 @@ data "triton_network" "private" {
 locals {
   cns_service_drill     = "drill"
   cns_service_zookeeper = "zookeeper"
-  address_zookeeper     = "${local.cns_service_zookeeper}.svc.${var.triton_account_uuid}.${var.triton_region}.cns.joyent.com"
 
   tag_role_drill     = "${var.project_name}-drill"
   tag_role_zookeeper = "${var.project_name}-zookeeper"

--- a/blueprints/drill/terraform/machines-drill.tf
+++ b/blueprints/drill/terraform/machines-drill.tf
@@ -22,14 +22,12 @@ resource "triton_machine" "drill" {
   }
 
   metadata {
-    version_zk_cli       = "${var.version_zk_cli}"
-    version_drill        = "${var.version_drill}"
-    md5_drill            = "${var.md5_drill}"
-    version_hadoop_manta = "${var.version_hadoop_manta}"
-    name_machine         = "${var.project_name}-drill-${count.index}"
-    triton_account_uuid  = "${var.triton_account_uuid}"
-    triton_region        = "${var.triton_region}"
-    address_zookeeper    = "${local.address_zookeeper}"
+    version_zk_cli        = "${var.version_zk_cli}"
+    version_drill         = "${var.version_drill}"
+    md5_drill             = "${var.md5_drill}"
+    version_hadoop_manta  = "${var.version_hadoop_manta}"
+    name_machine          = "${var.project_name}-drill-${count.index}"
+    cns_service_zookeeper = "${local.cns_service_zookeeper}"
 
     manta_url    = "${var.manta_url}"
     manta_user   = "${var.manta_user}"
@@ -41,8 +39,8 @@ resource "triton_machine" "drill" {
     # explicitly depend on the zookeeper machine because we're using the CNS address
     # and not directly depending on the resource otherwise
     "triton_machine.zookeeper",
-    "null_resource.zookeeper_install",
 
+    "null_resource.zookeeper_install",
     "triton_firewall_rule.drill_to_drill",
     "triton_firewall_rule.drill_to_zookeeper",
   ]

--- a/blueprints/drill/terraform/networks-firewalls.tf
+++ b/blueprints/drill/terraform/networks-firewalls.tf
@@ -20,9 +20,9 @@ resource "triton_firewall_rule" "external_to_drill" {
   rule    = "FROM all vms TO tag \"role\" = \"${local.tag_role_drill}\" ALLOW tcp PORT 8047"
   enabled = true
 }
+
 # see https://drill.apache.org/docs/ports-used-by-drill/
 resource "triton_firewall_rule" "drill_to_drill" {
   rule    = "FROM tag \"role\" = \"${local.tag_role_drill}\" TO tag \"role\" = \"${local.tag_role_drill}\" ALLOW tcp PORTS 31010 - 31012"
   enabled = true
 }
-

--- a/blueprints/drill/terraform/scripts/install_drill.sh
+++ b/blueprints/drill/terraform/scripts/install_drill.sh
@@ -572,13 +572,16 @@ function main() {
   local -r arg_md5_drill=$(/native/usr/sbin/mdata-get 'md5_drill')
   local -r arg_version_hadoop_manta=$(/native/usr/sbin/mdata-get 'version_hadoop_manta')
   local -r arg_name_machine=$(/native/usr/sbin/mdata-get 'name_machine')
-  local -r arg_triton_account_uuid=$(/native/usr/sbin/mdata-get 'triton_account_uuid')
-  local -r arg_triton_region=$(/native/usr/sbin/mdata-get 'triton_region')
-  local -r arg_address_zookeeper=$(/native/usr/sbin/mdata-get 'address_zookeeper')
+  local -r arg_cns_service_zookeeper=$(/native/usr/sbin/mdata-get 'cns_service_zookeeper')
   local -r arg_manta_url=$(/native/usr/sbin/mdata-get 'manta_url')
   local -r arg_manta_user=$(/native/usr/sbin/mdata-get 'manta_user')
   local -r arg_manta_key_id=$(/native/usr/sbin/mdata-get 'manta_key_id')
   local -r arg_manta_key=$(/native/usr/sbin/mdata-get 'manta_key')
+
+  local -r arg_triton_account_uuid=$(/native/usr/sbin/mdata-get 'sdc:owner_uuid') # see https://eng.joyent.com/mdata/datadict.html
+  local -r arg_triton_region=$(/native/usr/sbin/mdata-get 'sdc:datacenter_name') # see https://eng.joyent.com/mdata/datadict.html
+  local -r arg_address_zookeeper="${arg_cns_service_zookeeper}.svc.${arg_triton_account_uuid}.${arg_triton_region}.cns.joyent.com"
+
   check_arguments \
     ${arg_version_zk_cli} ${arg_version_drill} ${arg_md5_drill} ${arg_version_hadoop_manta} \
     ${arg_name_machine} ${arg_triton_account_uuid} ${arg_triton_region} ${arg_address_zookeeper} \

--- a/blueprints/drill/terraform/terraform.tfvars.example
+++ b/blueprints/drill/terraform/terraform.tfvars.example
@@ -1,5 +1,4 @@
 project_name = "drill-cluster"
-triton_account_uuid = ""
 
 manta_user = "your_account_name"
 manta_key_id = "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"


### PR DESCRIPTION
Within the Drill install script we're now using `mdata-get` to retrieve the account uuid and region as per https://eng.joyent.com/mdata/datadict.html.